### PR TITLE
add math lib import

### DIFF
--- a/examples/python_fastapi/app.py
+++ b/examples/python_fastapi/app.py
@@ -1,5 +1,6 @@
-from datetime import date, datetime
+import math
 
+from datetime import date, datetime
 from fastapi import FastAPI, HTTPException
 
 app = FastAPI()


### PR DESCRIPTION
In the "example" directory, within the python_fastapi folder, the import of the "math" package has been added to the app.py file.
The following is the report effect after running the run command without math package：
![image](https://github.com/user-attachments/assets/c0ab45eb-115f-4c89-800a-ba59e94da28e)
The effect after adding：
![image](https://github.com/user-attachments/assets/e3bcfba5-95d5-4e73-80ba-cf4e0dd0f6a9)

